### PR TITLE
Heapdump: `chdir()` to the previous working directory

### DIFF
--- a/servisor.js
+++ b/servisor.js
@@ -132,9 +132,11 @@ Servisor.prototype._runWorker = function() {
     // For 0.10: npm install heapdump
     process.on('SIGUSR2', function() {
         var heapdump = require('heapdump');
+        var cwd = process.cwd();
         console.error('SIGUSR2 received! Writing snapshot.');
         process.chdir('/tmp');
         heapdump.writeSnapshot();
+        process.chdir(cwd);
     });
 
     // Require service modules and start them


### PR DESCRIPTION
When doing a heap dump, the process' CWD is changed to `/tmp` in order to write the heap dump file. It is prudent `chdir()` back to the process' original working directory.