### PR TITLE
Minor enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+coverage
+node_modules
+npm-debug.log

--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,6 @@ services:
     
     # per-service config
     conf:
-        port: 12345
-        interface: localhost
-        # more per-service config settings
+      port: 12345
+      interface: localhost
+      # more per-service config settings

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
       "servisor": "./servisor.js"
   },
   "scripts": {
+    "start": "./servisor.js",
     "test": "mocha",
     "coverage": "sh test/utils/cleandb.sh && istanbul cover _mocha -- -R spec",
     "coveralls": "cat ./coverage/lcov.info | coveralls"

--- a/test/httpserver.js
+++ b/test/httpserver.js
@@ -18,6 +18,6 @@ module.exports = function (opts) {
                 });
                 res.end('okay');
             }
-        }).listen(8888, resolve);
+        }).listen(opts.config.port || 8888, opts.config.interface || '0.0.0.0', resolve);
     });
 };


### PR DESCRIPTION
* let the test HTTP server use the provided configuration
* add .gitignore
* define the `npm start` script for convenience
* fix indentation in `config.yaml`