### PR TITLE
Bug fix: Let servisor honour the number of workers to fork

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ packaging:
 
 # Number of worker processes to spawn. 
 # Set to 0 to run everything in a single process without clustering.
+# Use 'ncpu' to run as many workers as there are CPU units
 num_workers: 1
 
 # Logger info

--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@ packaging:
 # Number of worker processes to spawn. 
 # Set to 0 to run everything in a single process without clustering.
 # Use 'ncpu' to run as many workers as there are CPU units
-num_workers: 1
+num_workers: ncpu
 
 # Logger info
 logging:

--- a/servisor.js
+++ b/servisor.js
@@ -14,6 +14,7 @@ var cluster = require('cluster');
 var path = require('path');
 var yaml = require('js-yaml');
 var fs = Promise.promisifyAll(require('fs'));
+var os = require('os');
 
 
 var Logger = require('./lib/logger');
@@ -68,7 +69,7 @@ Servisor.prototype._sanitizeConfig = function (conf, options) {
         conf.num_workers = options.num_workers;
     } else if(conf.num_workers === 'ncpu') {
         // use the number of CPUs
-        conf.num_workers = require('os').cpus().length;
+        conf.num_workers = os.cpus().length;
     }
     return conf;
 };

--- a/servisor.js
+++ b/servisor.js
@@ -62,13 +62,13 @@ Servisor.prototype._sanitizeConfig = function (conf, options) {
     if (!conf.logging) { conf.logging = {}; }
     if (!conf.metrics) { conf.metrics = {}; }
     // check the number of workers to run
-    if(options.numWorkers !== -1) {
+    if(options.num_workers !== -1) {
         // the number of workers has been supplied
         // on the command line, so honour that
-        conf.num_workers = options.numWorkers;
+        conf.num_workers = options.num_workers;
     } else if(conf.num_workers === 'ncpu') {
         // use the number of CPUs
-        conf.num_workers = options.defNumWorkers;
+        conf.num_workers = require('os').cpus().length;
     }
     return conf;
 };
@@ -222,8 +222,7 @@ Servisor.prototype._getOptions = function (opts) {
     if (!opts) {
         // Use args
         opts = {
-            numWorkers: args.n,
-            defNumWorkers: require( "os" ).cpus().length,
+            num_workers: args.n,
             configFile: args.c
         };
     }

--- a/servisor.js
+++ b/servisor.js
@@ -67,7 +67,7 @@ Servisor.prototype._sanitizeConfig = function (conf, options) {
         // the number of workers has been supplied
         // on the command line, so honour that
         conf.num_workers = options.num_workers;
-    } else if(conf.num_workers === 'ncpu') {
+    } else if(conf.num_workers === 'ncpu' || typeof conf.num_workers !== 'number') {
         // use the number of CPUs
         conf.num_workers = os.cpus().length;
     }


### PR DESCRIPTION
A tiny naming bug prevented servisor from starting the sought number of workers. This commit fixes it. Concretely, if the user provides that number as a command-line argument, it is honoured. Otherwise, the num_workers stanza from the configuration file is used. Furthermore, clients can now set num_workers to 'ncpu' in the config, which causes servisor to start as many workers as there are available CPU units on the machine.